### PR TITLE
[FIX] Hilt 오류 해결

### DIFF
--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.hilt.gradle)
     alias(libs.plugins.kotlin.kapt)
     kotlin("plugin.serialization") version "1.5.0"
 }
@@ -42,5 +43,7 @@ dependencies {
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
     implementation(project(":core:domain"))
+    implementation(libs.hilt.android)
+    kapt(libs.hilt.compiler)
     implementation(libs.hilt.android)
 }


### PR DESCRIPTION
### 📌 내용
```kotlin
/Users/jiwon_dev/AndroidStudioProjects/PoketmonEncyclopedia/app/build/generated/hilt/component_sources/debug/com/poketmonencyclopedia/PoketmonEncyclopedia_HiltComponents.java:136: error: [Dagger/MissingBinding] com.poketmonencyclopedia.domain.detail.PoketmonDetailRepository cannot be provided without an @Provides-annotated method.
  public abstract static class SingletonC implements PoketmonEncyclopedia_GeneratedInjector,
                         ^
  
  Missing binding usage:
      com.poketmonencyclopedia.domain.detail.PoketmonDetailRepository is injected at
          com.poketmonencyclopedia.domain.detail.PoketmonDetailUseCase(poketmonDetailRepository)
      com.poketmonencyclopedia.domain.detail.PoketmonDetailUseCase is injected at
          com.poketmonencyclopedia.poketmondetail.PoketmonDetailViewModel(poketmonDetailUseCase)
      com.poketmonencyclopedia.poketmondetail.PoketmonDetailViewModel is injected at
          com.poketmonencyclopedia.poketmondetail.PoketmonDetailViewModel_HiltModules.BindsModule.binds(arg0)
      @dagger.hilt.android.internal.lifecycle.HiltViewModelMap java.util.Map<java.lang.String,javax.inject.Provider<androidx.lifecycle.ViewModel>> is requested at
          dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.ViewModelFactoriesEntryPoint.getHiltViewModelMap() [com.poketmonencyclopedia.PoketmonEncyclopedia_HiltComponents.SingletonC → com.poketmonencyclopedia.PoketmonEncyclopedia_HiltComponents.ActivityRetainedC → com.poketmonencyclopedia.PoketmonEncyclopedia_HiltComponents.ViewModelC]
```

### 🛠️ Done!
 - [x] Hilt 오류 해결

### TroubleShooting
- app 모듈에서 각 모듈을 추가했고, hilt module에도 이상한 점이 없었음에도 위 에러가 계속 발생했다.
- 모듈별 build.gradle을 보니 data module에만 hilt dependency와 plugin에 추가를 안해줬던 것..
- 같은 에러 발생시 위 2가지를 꼼꼼하게 체크할 것!

